### PR TITLE
Added an option that prevents turrets from targeting pets of owners and trusted players.

### DIFF
--- a/src/main/java/openmodularturrets/handler/ConfigHandler.java
+++ b/src/main/java/openmodularturrets/handler/ConfigHandler.java
@@ -68,6 +68,7 @@ public class ConfigHandler {
     private static boolean shouldSpawnDungeonLoot;
     private static String[] entityBlacklist;
     private static boolean debugEntityName;
+    private static boolean protectTrustedPets;
     public static boolean canOPAccessTurrets;
 
 
@@ -261,6 +262,9 @@ public class ConfigHandler {
         globalCanTargetNeutrals = config.get("GlobalTargetingParameters", "Can turrets attack neutrals?",
                 true).getBoolean();
 
+        protectTrustedPets = config.get("GlobalTargetingParameters", "Will turrets ignore pets of trusted players, true: turret does not attack pets :) , false: turret does attack pets :(",
+                true).getBoolean();
+
         globalCanTargetMobs = config.get("GlobalTargetingParameters", "Can turrets attack mobs?", true).getBoolean();
 
         canOPAccessTurrets = config.get("miscellaneous", "Can OPs access all turrets?", false).getBoolean();
@@ -293,6 +297,8 @@ public class ConfigHandler {
     public static String[] getEntityBlacklist() {return entityBlacklist;}
 
     public static boolean getDebugEntityName() {return debugEntityName;}
+
+    public static boolean getProtectTrustedPets() {return protectTrustedPets;}
 
     public static int getBaseTierOneMaxIo() {
         return baseTierOneMaxIo;

--- a/src/main/java/openmodularturrets/util/TurretHeadUtil.java
+++ b/src/main/java/openmodularturrets/util/TurretHeadUtil.java
@@ -1,13 +1,11 @@
 package openmodularturrets.util;
 
 import net.minecraft.block.Block;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityList;
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.EnumCreatureType;
+import net.minecraft.entity.*;
 import net.minecraft.entity.monster.IMob;
 import net.minecraft.entity.passive.EntityAmbientCreature;
 import net.minecraft.entity.passive.EntityAnimal;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -84,6 +82,18 @@ public class TurretHeadUtil {
         return ArrayUtils.contains(ConfigHandler.getEntityBlacklist(), EntityList.getEntityString(target));
     }
 
+    private static boolean targetIsTrustedPet(EntityLivingBase target,TurretBase base){
+
+        if (ConfigHandler.getProtectTrustedPets() && target instanceof IEntityOwnable){
+            Entity entityOwned = ((IEntityOwnable) target).getOwner();
+            if (entityOwned instanceof EntityPlayer) {
+                EntityPlayer owner = (EntityPlayer) entityOwned;
+                return isPlayerOwner(owner, base) || isTrustedPlayer(owner.getUniqueID(), base);
+            }
+        }
+        return false;
+    }
+
     public static Entity getTarget(TurretBase base, World worldObj, int downLowAmount, int xCoord, int yCoord, int zCoord, int turretRange, TurretHead turret) {
         Entity target = null;
 
@@ -100,6 +110,9 @@ public class TurretHeadUtil {
                     continue;
                 }
 
+                if(targetIsTrustedPet(target1,base)){
+                    continue;
+                }
 
                 if (base.isAttacksNeutrals() && ConfigHandler.globalCanTargetNeutrals) {
                     if (target1 instanceof EntityAnimal && !target1.isDead) {
@@ -158,6 +171,10 @@ public class TurretHeadUtil {
             for (EntityLivingBase target1 : targets) {
 
                 if(targetIsBlacklisted(target1)){
+                    continue;
+                }
+
+                if(targetIsTrustedPet(target1,base)){
                     continue;
                 }
 
@@ -224,6 +241,10 @@ public class TurretHeadUtil {
             for (EntityLivingBase target1 : targets) {
 
                 if(targetIsBlacklisted(target1)){
+                    continue;
+                }
+
+                if(targetIsTrustedPet(target1,base)){
                     continue;
                 }
 


### PR DESCRIPTION


This still has bug that when the trusted player logs out and the pet is in range of the turret the turret will start firing at it.